### PR TITLE
Bump .NET version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This project is still under development, so you may encounter bugs when using it. Even if the program creates a backup of your save, consider creating one manually.
 
 ## Presentation
-This save editor lets you to change stats of your campaigns, every vanilla slugcats are supported (this include DLC ones and Inv).  
+This save editor lets you change stats of your campaigns, every vanilla slugcats are supported (this include DLC ones and Inv).  
 For now only a few modded slugcats are supported :  
 
 * Vinki
@@ -15,9 +15,9 @@ For now only a few modded slugcats are supported :
 * Wingcat
 
 ## How to use
-/!\\ Make sure that you have [.NET 7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) installed or the program will close itself /!\\  
+/!\\ Make sure that you have [.NET 8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) installed or the program will close itself /!\\  
   
-Simply run RwSavEditor.exe and put manually the path to your save file (located in C:\\Users\\[user]\\AppData\\LocalLow\\Videocult\\Rain World\\) OR if the executable is in the same folder as your save, enter "./" to select in the current directory OR enter "find" to let the program search itself in the game's save directory.  
+Simply run RwSavEditor.exe and put manually the path to your save file (located in C:\\Users\\%USERNAME%\\AppData\\LocalLow\\Videocult\\Rain World\\) OR if the executable is in the same folder as your save, enter "./" to select in the current directory OR enter "find" to let the program search itself in the game's save directory.  
 Your antivirus may block the program at launch so be sure to disable it or make it accept the program.  
 If you want to change your spawn point, it is recommended to use the [Interactive Map](https://rain-world-map.github.io/map.html?slugcat=white&region=HI)
 
@@ -25,4 +25,4 @@ If you want to change your spawn point, it is recommended to use the [Interactiv
 If you find any problem in the program, or you just want to make a suggestion to improve the editor, send them in the [Discord server](https://discord.gg/ejNwfEqsTn)
 
 ## Supporting
-If you liked this project and you want to support me, you can do that [here](https://paypal.me/FnaRuta)
+If you liked this project, and you want to support me, you can do that [here](https://paypal.me/FnaRuta)

--- a/RwSavEditor/RwSavEditor.csproj
+++ b/RwSavEditor/RwSavEditor.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 	    <PublishSingleFile>true</PublishSingleFile>


### PR DESCRIPTION
The .NET 7.0 is no longer supported nor secure to use.

This PR bumps the .NET version to the current LTS, 8.0.